### PR TITLE
ビルドワークフローへの手動トリガーの追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - "master"
     paths:
       - "Dockerfile"
+  workflow_dispatch:
 
 jobs:
   docker:


### PR DESCRIPTION
ワークフロー定義のエラーなどでDockerfile変更時のビルドに失敗した場合、ワークフロー定義を直した後に手動で実行できるようになっていると便利なのでトリガーを追加します。ご活用ください。
（本当は #3 に含めるべきでしたが失念していました）